### PR TITLE
Implement campaign notification on login

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -91,7 +91,7 @@ export default defineConfig((/* ctx */) => {
       // directives: [],
 
       // Quasar plugins
-      plugins: [],
+      plugins: ['Notify'],
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -27,11 +27,13 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useQuasar } from 'quasar'
 
 // 🔧 Configuración
 const API_BASE_URL = 'https://medialert-backend-1q8e.onrender.com'
 
 const router = useRouter()
+const $q = useQuasar()
 const rut = ref('')
 const contrasena = ref('')
 const error = ref('')
@@ -78,6 +80,11 @@ const login = async () => {
     }
 
     localStorage.setItem('usuario', JSON.stringify(data))
+
+    $q.notify({
+      type: 'info',
+      message: 'Campaña activa: ¡recuerda revisar tus notificaciones!',
+    })
 
     const rol = data.rol?.toLowerCase().trim()
 


### PR DESCRIPTION
## Summary
- enable the Quasar Notify plugin
- show a global notification after the user logs in

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688180c674948327aa4dd6038aca93dc