### PR TITLE
Add login spinner dialog

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -21,6 +21,15 @@
         <q-btn label="Entrar" color="primary" @click="login" />
       </q-card-actions>
     </q-card>
+
+    <q-dialog v-model="loadingDialog" persistent>
+      <q-card>
+        <q-card-section class="row items-center q-pa-md">
+          <q-spinner color="primary" size="2em" />
+          <span class="q-ml-sm">Iniciando sesión...</span>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
   </q-page>
 </template>
 
@@ -37,6 +46,7 @@ const $q = useQuasar()
 const rut = ref('')
 const contrasena = ref('')
 const error = ref('')
+const loadingDialog = ref(false)
 
 const validarRut = (valor: string) => {
   const rutLimpio = valor.replace(/[^0-9kK]/g, '').toLowerCase()
@@ -87,16 +97,24 @@ const login = async () => {
     })
 
     const rol = data.rol?.toLowerCase().trim()
+    let destino = ''
 
     if (rol === 'cuidador') {
-      router.push('/cuidador')
+      destino = '/cuidador'
     } else if (rol === 'paciente') {
-      router.push('/paciente')
+      destino = '/paciente'
     } else if (rol === 'admin') {
-      router.push('/admin')
+      destino = '/admin'
     } else {
       error.value = 'Rol no reconocido'
+      return
     }
+
+    loadingDialog.value = true
+    setTimeout(() => {
+      loadingDialog.value = false
+      router.push(destino)
+    }, 5000)
   } catch (err) {
     console.error('❌ Error al conectar al backend:', err)
     error.value = 'No se pudo conectar al servidor'


### PR DESCRIPTION
## Summary
- show a QDialog with a spinner when login succeeds
- hide the dialog after **5** seconds then navigate

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68818373d8108327bb25a90a0da68320