### PR TITLE
Enable Dialog plugin for login spinner

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -91,7 +91,7 @@ export default defineConfig((/* ctx */) => {
       // directives: [],
 
       // Quasar plugins
-      plugins: ['Notify'],
+      plugins: ['Notify', 'Dialog'],
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -21,6 +21,7 @@
         <q-btn label="Entrar" color="primary" @click="login" />
       </q-card-actions>
     </q-card>
+
   </q-page>
 </template>
 
@@ -37,6 +38,7 @@ const $q = useQuasar()
 const rut = ref('')
 const contrasena = ref('')
 const error = ref('')
+let loginDialog: any | null = null
 
 const validarRut = (valor: string) => {
   const rutLimpio = valor.replace(/[^0-9kK]/g, '').toLowerCase()
@@ -64,6 +66,13 @@ const login = async () => {
     error.value = 'RUT inválido'
     return
   }
+
+  loginDialog = $q.dialog({
+    progress: true,
+    message: 'Iniciando sesión...',
+    ok: false,
+    persistent: true,
+  })
   try {
     const res = await fetch(`${API_BASE_URL}/login`, {
       method: 'POST',
@@ -76,6 +85,7 @@ const login = async () => {
 
     if (!res.ok) {
       error.value = data.error || 'Error al iniciar sesión'
+      loginDialog?.hide()
       return
     }
 
@@ -87,19 +97,28 @@ const login = async () => {
     })
 
     const rol = data.rol?.toLowerCase().trim()
+    let destino = ''
 
     if (rol === 'cuidador') {
-      router.push('/cuidador')
+      destino = '/cuidador'
     } else if (rol === 'paciente') {
-      router.push('/paciente')
+      destino = '/paciente'
     } else if (rol === 'admin') {
-      router.push('/admin')
+      destino = '/admin'
     } else {
       error.value = 'Rol no reconocido'
+      loginDialog?.hide()
+      return
     }
+
+    setTimeout(() => {
+      loginDialog?.hide()
+      router.push(destino)
+    }, 3000)
   } catch (err) {
     console.error('❌ Error al conectar al backend:', err)
     error.value = 'No se pudo conectar al servidor'
+    loginDialog?.hide()
   }
 }
 


### PR DESCRIPTION
## Summary
- enable `Dialog` plugin in Quasar config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68818373d8108327bb25a90a0da68320