### PR TITLE
Add high contrast option

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,1 +1,23 @@
 // app global css in SCSS form
+body {
+  font-size: 18px;
+}
+
+body.high-contrast {
+  background-color: #000;
+  color: #fff;
+}
+
+body.high-contrast a,
+body.high-contrast .text-primary {
+  color: #fff !important;
+}
+
+body.high-contrast .bg-primary {
+  background-color: #000 !important;
+}
+
+body.high-contrast .q-card {
+  background-color: #000;
+  color: #fff;
+}

--- a/src/pages/PacientePage.vue
+++ b/src/pages/PacientePage.vue
@@ -6,6 +6,13 @@
       </q-card-section>
       <q-card-section>
         <div class="text-subtitle1">Hora actual: {{ horaActual }}</div>
+        <q-btn
+          class="q-ml-sm"
+          color="primary"
+          flat
+          label="Alto Contraste"
+          @click="toggleContraste"
+        />
       </q-card-section>
     </q-card>
 
@@ -42,6 +49,17 @@ const medicamentos = ref([])
 const horaActual = ref('')
 const $q = useQuasar()
 const usuario = JSON.parse(localStorage.getItem('usuario'))
+
+const modoContraste = ref(false)
+
+function toggleContraste() {
+  modoContraste.value = !modoContraste.value
+  if (modoContraste.value) {
+    document.body.classList.add('high-contrast')
+  } else {
+    document.body.classList.remove('high-contrast')
+  }
+}
 
 function traducirDia(diaIngles) {
   const mapa = {
@@ -105,6 +123,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   clearInterval(timer)
+  document.body.classList.remove('high-contrast')
 })
 </script>
 


### PR DESCRIPTION
## Summary
- add 'Alto Contraste' toggle in Paciente page
- implement logic to apply high contrast mode
- enlarge base font size and high contrast styles

## Testing
- `npm test`
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825109e3988327a84eaab3e48dac19