### PR TITLE
Replace fetch with Axios api client

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -35,11 +35,11 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useQuasar } from 'quasar'
+import { api } from 'boot/axios'
 
 const $q = useQuasar()
 const router = useRouter()
 
-const API_BASE_URL = 'https://medialert-backend-1q8e.onrender.com'
 const rut = ref('')
 const contrasena = ref('')
 const error = ref('')
@@ -54,18 +54,10 @@ const login = async () => {
   }
 
   try {
-    const res = await fetch(`${API_BASE_URL}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rut: rut.value, contrasena: contrasena.value }),
+    const { data } = await api.post('/login', {
+      rut: rut.value,
+      contrasena: contrasena.value,
     })
-
-    const data = await res.json()
-
-    if (!res.ok) {
-      error.value = data.error || 'Error al iniciar sesión'
-      return
-    }
 
     localStorage.setItem('usuario', JSON.stringify(data))
 
@@ -89,7 +81,11 @@ const login = async () => {
     }, 6000)
   } catch (err) {
     console.error('❌ Error al conectar al backend:', err)
-    error.value = 'No se pudo conectar al servidor'
+    if (err.response) {
+      error.value = err.response.data?.error || 'Error al iniciar sesión'
+    } else {
+      error.value = 'No se pudo conectar al servidor'
+    }
   }
 }
 

--- a/src/pages/PacientePage.vue
+++ b/src/pages/PacientePage.vue
@@ -38,6 +38,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useQuasar } from 'quasar'
+import { api } from 'boot/axios'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
@@ -97,10 +98,7 @@ function confirmarToma(med) {
 
 let timer
 onMounted(async () => {
-  const res = await fetch(
-    `https://medialert-backend-1q8e.onrender.com/medicamentos_por_rut/${usuario.rut}`,
-  )
-  const data = await res.json()
+  const { data } = await api.get(`/medicamentos_por_rut/${usuario.rut}`)
 
   // Agregamos propiedad `confirmado` localmente para cada medicamento
   medicamentos.value = data.map((med) => ({ ...med, confirmado: false }))

--- a/src/pages/RegistroPage.vue
+++ b/src/pages/RegistroPage.vue
@@ -29,6 +29,7 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { api } from 'boot/axios'
 
 const router = useRouter()
 const nombre = ref('')
@@ -43,29 +44,23 @@ const registrar = async () => {
   error.value = ''
   success.value = ''
   try {
-    const res = await fetch('https://medialert-backend-1q8e.onrender.com/registro', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        nombre: nombre.value,
-        telefono: telefono.value,
-        rut: rut.value,
-        contrasena: contrasena.value,
-        rol: rol.value,
-      }),
+    const { data } = await api.post('/registro', {
+      nombre: nombre.value,
+      telefono: telefono.value,
+      rut: rut.value,
+      contrasena: contrasena.value,
+      rol: rol.value,
     })
 
-    const data = await res.json()
-
-    if (!res.ok) {
-      error.value = data.error || 'Error al registrar'
-    } else {
-      success.value = 'Registro exitoso'
-      setTimeout(() => router.push('/login'), 1000)
-    }
+    success.value = 'Registro exitoso'
+    setTimeout(() => router.push('/login'), 1000)
   } catch (err) {
     console.error(err)
-    error.value = 'No se pudo conectar al servidor'
+    if (err.response) {
+      error.value = err.response.data?.error || 'Error al registrar'
+    } else {
+      error.value = 'No se pudo conectar al servidor'
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- replace hard-coded fetch calls with the configured `api` client
- handle errors returned by the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68825b500e248327a30621c689b0ad58