### PR TITLE
Fix unused useQuasar import

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -34,10 +34,8 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { useQuasar } from 'quasar'
 import { api } from 'boot/axios'
 
-//const $q = useQuasar()
 const router = useRouter()
 
 const rut = ref('')


### PR DESCRIPTION
## Summary
- remove unused `useQuasar` import and constant from `LoginPage`

## Testing
- `npm test`
- `npm run lint` *(fails: `eslint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882830350748327acbec0c7f91aa81a