### PR TITLE
Fix generics syntax for refs

### DIFF
--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -142,8 +142,8 @@ const usuario = JSON.parse(
   localStorage.getItem('usuario') || '{}'
 ) as { rut: string }
 
-const pacientes = ref<Paciente[]>([])
-const pacientesConMedicamentos = ref<PacienteConMedicamento[]>([])
+const pacientes = ref([] as Paciente[])
+const pacientesConMedicamentos = ref([] as PacienteConMedicamento[])
 const rutPaciente = ref<string>('')
 const nombre = ref<string>('')
 const dosis = ref<string>('')


### PR DESCRIPTION
## Summary
- silence lint errors caused by generic syntax in `<script setup>`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68828cb37bf8832789f53a5ff6b80de3