### PR TITLE
Add logo to login page

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,6 +1,9 @@
 <template>
   <q-page class="flex flex-center">
     <q-card style="width: 400px">
+      <q-card-section class="text-center q-pb-none">
+        <q-img :src="logoImg" alt="Logo" style="width: 150px" class="q-mx-auto q-my-md" />
+      </q-card-section>
       <q-card-section>
         <div class="text-h6">Iniciar Sesión</div>
       </q-card-section>
@@ -35,6 +38,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from 'boot/axios'
+import logoImg from '../assets/LOGO.png'
 
 const router = useRouter()
 


### PR DESCRIPTION
## Summary
- display src/assets/LOGO.png above the login form on LoginPage

## Testing
- `npm run lint` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6882983aaad883279bb43864e5a2b1ec