### PR TITLE
Fix medication loading in caregiver page

### DIFF
--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -99,20 +99,11 @@
           <q-input v-model="editData.dosis" label="Dosis" />
           <div>
             <div class="text-subtitle2">Días:</div>
-            <q-option-group
-              type="checkbox"
-              :options="diasSemana"
-              v-model="editDias"
-              inline
-            />
+            <q-option-group type="checkbox" :options="diasSemana" v-model="editDias" inline />
           </div>
           <div>
             <div class="text-subtitle2">Horas:</div>
-            <q-time
-              v-model="editHoraTemporal"
-              format24h
-              @update:model-value="agregaHoraEdicion"
-            />
+            <q-time v-model="editHoraTemporal" format24h @update:model-value="agregaHoraEdicion" />
             <div class="q-mt-sm">
               <q-chip
                 v-for="(h, i) in editHoras"
@@ -151,13 +142,7 @@
                 </q-item-label>
               </q-item-section>
               <q-item-section side>
-                <q-btn
-                  flat
-                  round
-                  icon="edit"
-                  color="primary"
-                  @click="abrirEditar(med)"
-                />
+                <q-btn flat round icon="edit" color="primary" @click="abrirEditar(med)" />
                 <q-btn
                   flat
                   round
@@ -202,6 +187,14 @@ const columns = [
   { name: 'acciones', label: 'Acciones', field: 'acciones' },
 ]
 
+function normalizarMedicamento(m) {
+  return {
+    ...m,
+    dias: Array.isArray(m.dias) ? m.dias.join(', ') : m.dias,
+    horas: Array.isArray(m.horas) ? m.horas.join(', ') : m.horas,
+  }
+}
+
 const diasSemana = [
   { label: 'Lunes', value: 'Lunes' },
   { label: 'Martes', value: 'Martes' },
@@ -235,7 +228,10 @@ async function cargarPacientesConMedicamentos() {
 
     for (const p of pacs) {
       const { data: meds } = await api.get(`/medicamentos_por_rut/${p.rut}`)
-      pacientesConMedicamentos.value.push({ ...p, medicamentos: meds })
+      pacientesConMedicamentos.value.push({
+        ...p,
+        medicamentos: meds.map(normalizarMedicamento),
+      })
     }
   } catch (err) {
     console.error(err)
@@ -251,7 +247,7 @@ async function cargarMedicamentos(rut) {
   if (!rut) return
   try {
     const { data } = await api.get(`/medicamentos_por_rut/${rut}`)
-    medicamentos.value = data
+    medicamentos.value = data.map(normalizarMedicamento)
   } catch (err) {
     console.error(err)
     $q.notify({ type: 'negative', message: 'Error al cargar medicamentos' })
@@ -278,8 +274,18 @@ function eliminarHoraEdicion(i) {
 
 function abrirEditar(m) {
   editData.value = { ...m }
-  editDias.value = m.dias ? m.dias.split(',').map((d) => d.trim()) : []
-  editHoras.value = m.horas ? m.horas.split(',').map((h) => h.trim()) : []
+  const diasParsed = Array.isArray(m.dias)
+    ? m.dias
+    : m.dias
+      ? m.dias.split(',').map((d) => d.trim())
+      : []
+  const horasParsed = Array.isArray(m.horas)
+    ? m.horas
+    : m.horas
+      ? m.horas.split(',').map((h) => h.trim())
+      : []
+  editDias.value = diasParsed
+  editHoras.value = horasParsed
   editHoraTemporal.value = ''
   editDialog.value = true
 }


### PR DESCRIPTION
## Summary
- normalize medication data when loading from API
- handle array values when editing medications

## Testing
- `npm run lint` *(fails: Cannot find package `globals`)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6882d4ad4e088327acd8684c9440badd