### PR TITLE
Fix initial patient selection

### DIFF
--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -224,6 +224,9 @@ async function cargarPacientesConMedicamentos() {
   try {
     const { data: pacs } = await api.get(`/pacientes_por_cuidador/${usuario.rut}`)
     pacientes.value = pacs
+    if (!rutPaciente.value && pacs.length) {
+      rutPaciente.value = pacs[0].rut
+    }
     pacientesConMedicamentos.value = []
 
     for (const p of pacs) {


### PR DESCRIPTION
## Summary
- set the first patient as the current one once patients are loaded

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68838b8353688327b94f305ec2e5dd76