### PR TITLE
Update README with npm install reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ yarn
 npm install
 ```
 
+Before running `quasar dev` or `npm run lint`, install the dependencies:
+
+```bash
+npm install
+```
+
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
 ```bash
 quasar dev


### PR DESCRIPTION
## Summary
- clarify that `npm install` must be run before `npm run lint` or development

## Testing
- `npm install` *(fails: could not reach registry)*
- `npm run lint` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6883920558b48327990c472cdb910ac5