### PR TITLE
Remove eslint disable

### DIFF
--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -160,7 +160,6 @@
 </template>
 
 <script setup>
-/* eslint-disable */
 import { ref, onMounted, watch, computed } from 'vue'
 import { useQuasar } from 'quasar'
 import { api } from 'boot/axios'


### PR DESCRIPTION
## Summary
- drop the `/* eslint-disable */` comment from `CuidadorPage.vue`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68839202479c83278e294fe8bb503fbd