### PR TITLE
Guard console logs

### DIFF
--- a/src/pages/AdminPage.vue
+++ b/src/pages/AdminPage.vue
@@ -104,7 +104,9 @@ const cargarAsignaciones = async () => {
   try {
     const res = await api.get('/admin/asignaciones')
     asignaciones.value = res.data
-    console.log('Asignaciones:', res.data)
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Asignaciones:', res.data)
+    }
   } catch (err) {
     error.value = 'No se pudieron cargar las asignaciones'
     console.error(err)
@@ -129,7 +131,9 @@ function guardarAsignacion() {
 
 function eliminarAsignacion(row) {
   // Aquí podrías eliminar la asignación en el backend
-  console.log('Eliminar asignación', row)
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Eliminar asignación', row)
+  }
 }
 
 onMounted(cargarAsignaciones)

--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -322,13 +322,15 @@ async function eliminarMedicamento(row) {
 }
 
 async function agregarMedicamento() {
-  console.log('👉 agregarMedicamento() called with:', {
-    nombre: nombre.value,
-    dosis: dosis.value,
-    dias: dias.value,
-    horas: horas.value,
-    rut_paciente: rutPaciente.value,
-  })
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('👉 agregarMedicamento() called with:', {
+      nombre: nombre.value,
+      dosis: dosis.value,
+      dias: dias.value,
+      horas: horas.value,
+      rut_paciente: rutPaciente.value,
+    })
+  }
 
   loading.value = true
   try {
@@ -339,7 +341,9 @@ async function agregarMedicamento() {
       horas: Array.isArray(horas.value) ? horas.value.join(', ') : horas.value,
       rut_paciente: rutPaciente.value,
     })
-    console.log('✅ POST /medicamentos_por_rut response:', resp.data)
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('✅ POST /medicamentos_por_rut response:', resp.data)
+    }
     $q.notify({ type: 'positive', message: 'Medicamento agregado' })
     await cargarMedicamentos(rutPaciente.value)
     await cargarPacientesConMedicamentos()


### PR DESCRIPTION
## Summary
- prevent `console.log` from running in production

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688390ff2f0083278f09a26a6b6ef663