### PR TITLE
Add API_URL config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,13 @@ npm run format
 quasar build
 ```
 
+### API base URL
+Set `API_URL` to change the backend endpoint used by Axios.
+
+```bash
+API_URL=https://example.com quasar dev
+```
+If not provided, it defaults to `http://localhost:3000`.
+
 ### Customize the configuration
 See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-config-js).

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -45,7 +45,9 @@ export default defineConfig((/* ctx */) => {
 
       publicPath: './',
       // analyze: true,
-      // env: {},
+      env: {
+        API_URL: process.env.API_URL || 'http://localhost:3000',
+      },
       // rawDefine: {}
       // ignorePublicFolder: true,
       // minify: false,

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -2,7 +2,7 @@ import { boot } from 'quasar/wrappers'
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: 'https://medialert-backend-1q8e.onrender.com',
+  baseURL: process.env.API_URL || 'http://localhost:3000',
 })
 
 export default boot(({ app }) => {


### PR DESCRIPTION
## Summary
- allow setting API URL via environment variable in axios boot file
- expose API_URL default in Quasar build config
- document API_URL usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/medialert-frontend/node_modules/globals/index.js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688391ff2ae483279061fe35045ad8fa