### PR TITLE
Ensure caregiver POST sends arrays with rut

### DIFF
--- a/src/pages/CuidadorPage.vue
+++ b/src/pages/CuidadorPage.vue
@@ -328,6 +328,7 @@ async function agregarMedicamento() {
       dias: dias.value,
       horas: horas.value,
       rut_paciente: rutPaciente.value,
+      rut_cuidador: usuario.rut,
     })
   }
 
@@ -336,8 +337,8 @@ async function agregarMedicamento() {
     const resp = await api.post('/medicamentos_por_rut', {
       nombre: nombre.value,
       dosis: dosis.value,
-      dias: Array.isArray(dias.value) ? dias.value.join(', ') : dias.value,
-      horas: Array.isArray(horas.value) ? horas.value.join(', ') : horas.value,
+      dias: dias.value,
+      horas: horas.value,
       rut_paciente: rutPaciente.value,
       rut_cuidador: usuario.rut,
     })


### PR DESCRIPTION
## Summary
- log `rut_cuidador` and send `dias`/`horas` as arrays when adding medications

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6883b03996f48327ac11b0fa77e32d9f