### PR TITLE
Point API to remote backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_URL=https://medialert-backend-1q8e.onrender.com

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ quasar build
 ```
 
 ### API base URL
-Set `API_URL` to change the backend endpoint used by Axios.
+Set `API_URL` to change the backend endpoint used by Axios. You can also create a `.env` file with this variable so it is picked up automatically.
 
 ```bash
 API_URL=https://example.com quasar dev
 ```
-If not provided, it defaults to `http://localhost:3000`.
+If not provided, it defaults to `https://medialert-backend-1q8e.onrender.com`.
 
 ### Customize the configuration
 See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-config-js).

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -46,7 +46,7 @@ export default defineConfig((/* ctx */) => {
       publicPath: './',
       // analyze: true,
       env: {
-        API_URL: process.env.API_URL || 'http://localhost:3000',
+        API_URL: process.env.API_URL || 'https://medialert-backend-1q8e.onrender.com',
       },
       // rawDefine: {}
       // ignorePublicFolder: true,


### PR DESCRIPTION
## Summary
- default API_URL points to remote backend instead of localhost
- document `.env` usage in README for API_URL
- add default API_URL to `.env`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6883d284762483278e653db580a14ca1