### PR TITLE
Remove Quasar branding from layout

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,7 +8,6 @@
           MediAlert
         </q-toolbar-title>
 
-        <div>Quasar v{{ $q.version }}</div>
       </q-toolbar>
     </q-header>
 

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="flex flex-center">
-    <div class="text-h4">¡Funciona Quasar!</div>
+    <div class="text-h4">¡Funciona!</div>
   </q-page>
 </template>
 


### PR DESCRIPTION
## Summary
- remove Quasar version from the layout toolbar
- replace placeholder text on index page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68840f774a9c8327b7c187731e705781